### PR TITLE
Added support for responses longer than 4 hex digits

### DIFF
--- a/src/ELMduino.cpp
+++ b/src/ELMduino.cpp
@@ -640,12 +640,14 @@ uint32_t ELM327::findResponse()
 		else
 			payBytes = recBytes - firstDatum;
 
-		// Some PID queries return 4 hex digit values - the
-		// rest return 2 hex digit values
-		if (payBytes >= 4)
-			return (ctoi(payload[firstDatum]) << 12) | (ctoi(payload[firstDatum + 1]) << 8) | (ctoi(payload[firstDatum + 2]) << 4) | ctoi(payload[firstDatum + 3]);
-		else
-			return (ctoi(payload[firstDatum]) << 4) | ctoi(payload[firstDatum + 1]);
+
+		uint32_t response = 0;
+		for(uint8_t i = 0; i < payBytes; i++) {
+			uint8_t payloadIndex = firstDatum + i;
+			uint8_t bitsOffset = 4 * (payBytes - i - 1);
+			response = response | (ctoi(payload[payloadIndex]) << bitsOffset);
+		}
+		return response;
 	}
 
 	return 0;


### PR DESCRIPTION
There are PID commands that result in responses longer than 4 hex digits. For example `223277` code for opel insignia returns 6 hex digits response (kms since last dpf regeneration). I logged some variables when debugging the PID:
```
 query: 223277
 firstHeadIndex: 6
 secondHeadIndex: -1
 payload: 22327762327700000E
 header: 623277
 firstDatum: 12
 recBytes: 18
 payBytes: 6
```
As you can see the response should be `00000E` (15km since dpf regeneration) but currently it returns `0000` since implementation is fixed on only two types of responses size (2 and 4 digits).

I added more generic implementation which reads everything from `firstDatum` till the end thus allowing any response size.

I've done some regression testing with multiple commands on opel insignia and found it works fine

Let me know what you think