### PR TITLE
send command should not reset connected status

### DIFF
--- a/src/ELMduino.cpp
+++ b/src/ELMduino.cpp
@@ -505,7 +505,6 @@ float ELM327::rpm()
 int8_t ELM327::sendCommand(const char *cmd)
 {
 	uint8_t counter = 0;
-	connected = false;
 
 	for (byte i = 0; i < PAYLOAD_LEN; i++)
 		payload[i] = '\0';
@@ -550,8 +549,6 @@ int8_t ELM327::sendCommand(const char *cmd)
 		status = ELM_UNABLE_TO_CONNECT;
 		return status;
 	}
-
-	connected = true;
 
 	if (nextIndex(payload, "NODATA") >= 0)
 	{


### PR DESCRIPTION
I am not sure if this is a proper fix to the timeout issue mentioned here. Once you get a timeout you are basically stuck in timeout status and cannot get any further command out. I've tested in Wifi mode, and here maybe you sometimes just have a lag in wifi connection which result in a timeout. But further requests will be success.

https://github.com/PowerBroker2/ELMduino/issues/41#issuecomment-735378288