### PR TITLE
Update ELMduino.cpp

### DIFF
--- a/src/ELMduino.cpp
+++ b/src/ELMduino.cpp
@@ -2367,7 +2367,7 @@ uint16_t ELM327::auxSupported()
 */
 int8_t ELM327::sendCommand(const char *cmd)
 {
-	uint8_t counter = 0;
+	uint16_t counter = 0;
 	connected = false;
     
 	// clear payload buffer


### PR DESCRIPTION
increased counter size as there are some pids which gets payload more than 255 bytes. For example Hyundai Ioniq EV 2101
Sample response: 7EC103D6101FFFFFFFF7ED10336101FFFFFBC07EA10166101FFE000007EB101E6101000003FF7ED2100991A94DF59A67EE037F21127EC219926112648A3FF7EA21092112380636037EB210838019994ED367EC22A60EDB0E0D0E0F7ED220472A6024700BB7EA2200000000A871347EB220000000A0027027EC230D0D0E000EC60A7ED23057143102000C87EA23072000000000007EB233F04DE360000007ED24078C014C7600177EC24C53800008A00037EB24000000000000007ED25001301F495272A7EC25099200030723007ED26C10012003203E77EC26011A24000110287EC2700B1D46309017C7ED27058401000000007EC280000000003E800