### PR TITLE
Make library non-blocking

### DIFF
--- a/examples/ESP32_M5Stack_Core2_non_block/non blocking M5Stack Core2.ino
+++ b/examples/ESP32_M5Stack_Core2_non_block/non blocking M5Stack Core2.ino
@@ -1,0 +1,253 @@
+#include <ELMduino.h>
+#include <M5Unified.h>
+
+#include "BluetoothSerial.h"
+
+ELM327 myELM327;
+BluetoothSerial SerialBT;
+
+char txt[80] = "";
+
+// #define USE_MAC_NAME // Comment this line out to specify OBDII scanner bluetooth mac address. Uncomment to specify bluetooth name
+#if defined USE_MAC_NAME
+char bt_name[] = "OBDLink LX";
+// char bt_name[] = "OBDII";
+// char bt_name[] = "V-LINK";
+#else
+// char bluetooth_mac_str[] = "00:1D:A5:68:98:8C"; // EM327 mini clone Blue
+// char bluetooth_mac_str[] = "00:1D:A5:22:69:9F"; // VGate iCar Pro black and gold
+char bluetooth_mac_str[] = "00:1d:a5:22:5f:f6";  // VGate iCar Pro black and gold
+// char bluetooth_mac_str[] = "00:04:3E:53:5E:0D";
+// char bluetooth_mac_str[] = "00:04:3E:53:5E:0D"; // OBDLink LX green
+uint8_t bt_mac[6] = {0x00};
+#endif
+char pin[] = "1234";
+
+typedef enum { IDLE,
+               BARO_PRESS,
+               COOLANT_TEMP,
+               OIL_TEMP,
+               MANIFOLD_PRESS,
+               ENG_RPM,
+               BATT_VOLT } obd_pid_states;
+
+obd_pid_states obd_state = IDLE;
+float coolant_temperature = 0.0;
+float battery_voltage = 0.0;
+float eng_rpm = 0.0;
+uint32_t slow_data_last_time = millis();
+uint32_t fast_data_last_time = millis();
+
+void setup() {
+  auto cfg = M5.config();
+  cfg.serial_baudrate = 115200;  // default=115200. if "Serial" is not needed, set it to 0.
+  cfg.clear_display = true;      // default=true. clear the screen when begin.
+  cfg.output_power = false;      // default=true. use external port 5V output.
+  cfg.internal_imu = false;      // default=true. use internal IMU.
+  cfg.internal_rtc = true;       // default=true. use internal RTC.
+  cfg.external_imu = false;      // default=false. use Unit Accel & Gyro.
+  cfg.external_rtc = false;      // default=false. use Unit RTC.
+  cfg.led_brightness = 0;        // default= 0. Green LED brightness (0=off / 255=max) (※ not NeoPixel)
+
+  M5.begin(cfg);
+  M5.Lcd.setBrightness((70 * 255) / 100);  // Set LCD brightness to 70% of maximum
+
+  M5.Lcd.setFont(&fonts::FreeSans12pt7b);
+  M5.Lcd.setTextDatum(top_left);
+  M5.Lcd.setTextPadding(0);
+  M5.Lcd.setTextColor(TFT_GREEN, TFT_BLACK);
+
+  uint16_t xx = 0;
+  uint16_t yy = 10;
+  M5.Lcd.setTextColor(TFT_ORANGE, TFT_BLACK);
+  sprintf(txt, "%s", "Starting ESP32 BT");
+  Serial.println(txt);
+  M5.Lcd.drawString(txt, xx, yy);
+
+  // Start ESP32 bluetooth
+  SerialBT.begin("ELM_NonBlock", true);
+
+  M5.Lcd.setTextPadding(M5.Lcd.textWidth(txt) + 10);
+  M5.Lcd.setTextColor(TFT_CYAN, TFT_BLACK);
+  sprintf(txt, "%s", "BT Started");
+  Serial.println(txt);
+  M5.Lcd.drawString(txt, xx, yy);
+
+  yy += M5.Lcd.fontHeight();
+  M5.Lcd.setTextColor(TFT_ORANGE, TFT_BLACK);
+  M5.Lcd.setFont(&fonts::FreeSans9pt7b);
+  sprintf(txt, "%s", "Trying to connect OBDII scanner");
+  Serial.println(txt);
+  M5.Lcd.drawString(txt, xx, yy);
+
+  yy += M5.Lcd.fontHeight();
+  M5.Lcd.setTextColor(TFT_GREEN, TFT_BLACK);
+  bool bt_connected = false;
+// Attempt to connect ESP32 to bluetooth OBDII scanner
+// SerialBT.setPin(pin);
+#if defined USE_MAC_NAME
+  sprintf(txt, "%s = %s", "BT Name", bt_name);
+  Serial.println(txt);
+  M5.Lcd.drawString(txt, xx, yy);
+  bt_connected = SerialBT.connect(bt_name);
+#else
+  // Convert bluetooth MAC address string into integer array[6]
+  sscanf(bluetooth_mac_str, "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx",
+         bt_mac, bt_mac + 1, bt_mac + 2,
+         bt_mac + 3, bt_mac + 4, bt_mac + 5);
+  sprintf(txt, "%s = %s", "MAC address", bluetooth_mac_str);
+  Serial.println(txt);
+  M5.Lcd.drawString(txt, xx, yy);
+  bt_connected = SerialBT.connect(bt_mac);
+#endif
+
+  yy += M5.Lcd.fontHeight();
+
+  if (!bt_connected) {
+    sprintf(txt, "%s", "Can't connect OBD - Phase 1");
+    Serial.println(txt);
+    M5.Lcd.setTextColor(TFT_RED, TFT_BLACK);
+    M5.Lcd.drawString(txt, xx, yy);
+    while (1)
+      ;
+  }
+
+  M5.Lcd.setTextColor(TFT_CYAN, TFT_BLACK);
+  sprintf(txt, "%s", "Phase 1 ok");
+  Serial.println(txt);
+  M5.Lcd.drawString(txt, xx, yy);
+
+  yy += M5.Lcd.fontHeight();
+  M5.Lcd.setTextColor(TFT_ORANGE, TFT_BLACK);
+  sprintf(txt, "%s", "Trying to start ELM327");
+  Serial.println(txt);
+  M5.Lcd.drawString(txt, xx, yy);
+
+  bt_connected = myELM327.begin(SerialBT, true, 2000);
+
+  yy += M5.Lcd.fontHeight();
+
+  if (!bt_connected) {
+    sprintf(txt, "%s", "Can't connect OBD - Phase 2");
+    Serial.println(txt);
+    M5.Lcd.setTextColor(TFT_RED, TFT_BLACK);
+    M5.Lcd.drawString(txt, xx, yy);
+
+    while (1)
+      ;
+  }
+
+  M5.Lcd.setTextColor(TFT_CYAN, TFT_BLACK);
+  sprintf(txt, "%s", "Phase 2 ok");
+  Serial.println(txt);
+  M5.Lcd.drawString(txt, xx, yy);
+
+  delay(2000);
+
+  M5.Lcd.clear();
+
+  // Label for Coolant Temperature
+  xx = 0;
+  M5.Lcd.setFont(&fonts::FreeSans12pt7b);
+  M5.Lcd.setTextDatum(top_left);
+  M5.Lcd.setTextPadding(100);
+  M5.Lcd.setTextColor(TFT_ORANGE, TFT_BLACK);
+  M5.Lcd.drawString("Coolant Temp:", xx, 10);
+
+  // Label for RPM
+  M5.Lcd.setTextColor(TFT_ORANGE, TFT_BLACK);
+  M5.Lcd.drawString("RPM:", xx, 50);
+
+  // Label for battery voltage
+  M5.Lcd.setTextColor(TFT_ORANGE, TFT_BLACK);
+  M5.Lcd.drawString("Battery:", xx, 90);
+
+}
+
+void loop() {
+  uint16_t xx = 180;
+  uint16_t yy = 10;
+
+  switch (obd_state) {
+    case IDLE:
+      if (millis() > slow_data_last_time + 5000) {
+        slow_data_last_time = millis();
+        obd_state = BATT_VOLT;
+        Serial.printf("IDLE, query SLOW PIDs at %.3f s\n", slow_data_last_time / 1000.0);
+      } else if (millis() > fast_data_last_time + 1000) {
+        fast_data_last_time = millis();
+        obd_state = COOLANT_TEMP;
+        Serial.printf("IDLE, query FAST PIDs at %.3f s\n", fast_data_last_time / 1000.0);
+      } else {
+        // Serial.printf("[%.3f s] IDLE\n", millis() / 1000.0);
+      }
+      break;
+
+    case BARO_PRESS:
+      break;
+
+    case COOLANT_TEMP:
+      coolant_temperature = myELM327.engineCoolantTemp();
+      yy = 10;
+      if (myELM327.nb_rx_state == ELM_SUCCESS) {
+        // Display coolant temperature
+        M5.Lcd.setTextColor(TFT_CYAN, TFT_BLACK);
+        sprintf(txt, "%.0f deg", coolant_temperature);
+        M5.Lcd.drawString(txt, xx, yy);
+        Serial.printf("Coolant temp = %s\n", txt);
+        obd_state = ENG_RPM;
+      } else if (myELM327.nb_rx_state != ELM_GETTING_MSG) {
+        myELM327.printError();
+        M5.Lcd.setTextColor(TFT_RED, TFT_BLACK);
+        sprintf(txt, "%s", "N/A deg");
+        M5.Lcd.drawString(txt, xx, yy);
+        obd_state = ENG_RPM;
+      }
+      break;
+
+    case OIL_TEMP:
+      break;
+
+    case MANIFOLD_PRESS:
+      break;
+
+    case ENG_RPM:
+      eng_rpm = myELM327.rpm();
+      yy = 50;
+      if (myELM327.nb_rx_state == ELM_SUCCESS) {
+        // Display coolant temperature
+        M5.Lcd.setTextColor(TFT_CYAN, TFT_BLACK);
+        sprintf(txt, "%.0f RPM", eng_rpm);
+        M5.Lcd.drawString(txt, xx, yy);
+        Serial.printf("Engine RPM = %s\n", txt);
+        obd_state = IDLE;
+      } else if (myELM327.nb_rx_state != ELM_GETTING_MSG) {
+        myELM327.printError();
+        M5.Lcd.setTextColor(TFT_RED, TFT_BLACK);
+        sprintf(txt, "%s", "N/A RPM");
+        M5.Lcd.drawString(txt, xx, yy);
+        obd_state = IDLE;
+      }
+      break;
+
+    case BATT_VOLT:
+      battery_voltage = myELM327.batteryVoltage();
+      yy = 90;
+      if (myELM327.nb_rx_state == ELM_SUCCESS) {
+        // Display vehicle battery voltage
+        M5.Lcd.setTextColor(TFT_CYAN, TFT_BLACK);
+        sprintf(txt, "%.1f VDC", battery_voltage);
+        M5.Lcd.drawString(txt, xx, yy);
+        Serial.printf("Battery voltage = %s\n", txt);
+
+        obd_state = IDLE;
+      } else if (myELM327.nb_rx_state != ELM_GETTING_MSG) {
+        myELM327.printError();
+        M5.Lcd.setTextColor(TFT_RED, TFT_BLACK);
+        sprintf(txt, "%s", "N/A VDC");
+        M5.Lcd.drawString(txt, xx, yy);
+        obd_state = IDLE;
+      }
+      break;
+  }
+}

--- a/examples/non_blocking_1/non blocking example 1.ino
+++ b/examples/non_blocking_1/non blocking example 1.ino
@@ -1,0 +1,55 @@
+#include "BluetoothSerial.h"
+#include "ELMduino.h"
+
+
+BluetoothSerial SerialBT;
+#define ELM_PORT   SerialBT
+#define DEBUG_PORT Serial
+
+
+ELM327 myELM327;
+
+
+uint32_t rpm = 0;
+
+uint8_t bt_mac[6] = {0x00, 0x1d, 0xa5, 0x22, 0x5f, 0xf6};
+
+void setup()
+{
+#if LED_BUILTIN
+  pinMode(LED_BUILTIN, OUTPUT);
+  digitalWrite(LED_BUILTIN, LOW);
+#endif
+
+  DEBUG_PORT.begin(115200);
+  // SerialBT.setPin("1234");
+  ELM_PORT.begin("ArduHUD", true);
+  
+  if (!ELM_PORT.connect(bt_mac))
+  {
+    DEBUG_PORT.println("Couldn't connect to OBD scanner - Phase 1");
+    while(1);
+  }
+
+  if (!myELM327.begin(ELM_PORT, true, 2000))
+  {
+    Serial.println("Couldn't connect to OBD scanner - Phase 2");
+    while (1);
+  }
+
+  Serial.println("Connected to ELM327");
+}
+
+
+void loop()
+{
+  float tempRPM = myELM327.rpm();
+
+  if (myELM327.nb_rx_state == ELM_SUCCESS)
+  {
+    rpm = (uint32_t)tempRPM;
+    Serial.print("RPM: "); Serial.println(rpm);
+  }
+  else if (myELM327.nb_rx_state != ELM_GETTING_MSG)
+    myELM327.printError();
+}

--- a/examples/non_blocking_2/non blocking example 2.ino
+++ b/examples/non_blocking_2/non blocking example 2.ino
@@ -1,0 +1,127 @@
+#include <ELMduino.h>
+#include "BluetoothSerial.h"
+
+ELM327 myELM327;
+BluetoothSerial SerialBT;
+
+char txt[80] = "";
+
+// #define USE_MAC_NAME // Comment this line out to specify OBDII scanner bluetooth mac address. Uncomment to specify bluetooth name
+#if defined USE_MAC_NAME
+char bt_name[] = "OBDII";
+#else
+char bluetooth_mac_str[] = "00:1d:a5:22:5f:f6";  // VGate iCar Pro black and gold
+uint8_t bt_mac[6] = {0x00};
+#endif
+char pin[] = "1234";
+
+typedef enum { IDLE,
+               COOLANT_TEMP,
+               OIL_TEMP,
+               ENG_RPM,
+               BATT_VOLT } obd_pid_states;
+
+obd_pid_states obd_state = IDLE;
+float coolant_temperature = 0.0;
+float battery_voltage = 0.0;
+float eng_rpm = 0.0;
+uint32_t slow_data_last_time = millis();
+uint32_t fast_data_last_time = millis();
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println(F("Starting ESP32 BT"));
+
+  // Start ESP32 bluetooth
+  SerialBT.begin("ELM_NonBlock", true);
+
+  Serial.println(F("BT Started"));
+  Serial.println(F("Trying to connect OBDII scanner"));
+
+  bool bt_connected = false;
+// Attempt to connect ESP32 to bluetooth OBDII scanner
+// SerialBT.setPin(pin);
+#if defined USE_MAC_NAME
+  Serial.printf("%s = %s\n", "BT Name", bt_name);
+  bt_connected = SerialBT.connect(bt_name);
+#else
+  // Convert bluetooth MAC address string into integer array[6]
+  sscanf(bluetooth_mac_str, "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx",
+         bt_mac, bt_mac + 1, bt_mac + 2,
+         bt_mac + 3, bt_mac + 4, bt_mac + 5);
+  Serial.printf("%s = %s\n", "MAC address", bluetooth_mac_str);
+  bt_connected = SerialBT.connect(bt_mac);
+#endif
+
+  if (!bt_connected) {
+    Serial.println(F("Couldn't connect to OBD scanner - Phase 1"));
+    while (1);
+  }
+
+  Serial.println(F("Phase 1 ok. Trying to start ELM327"));
+  bt_connected = myELM327.begin(SerialBT, true, 2000);
+
+  if (!bt_connected) {
+    Serial.println("Couldn't connect to OBD scanner - Phase 2");
+    while (1);
+  }
+
+  Serial.println(F("Phase 2 ok"));
+}
+
+void loop() {
+  switch (obd_state) {
+    case IDLE:
+      // Schedule PIDs to be read at different rates (slow PIDs and fast PIDs)
+      if (millis() > slow_data_last_time + 5000) {
+        slow_data_last_time = millis();
+        obd_state = BATT_VOLT;
+        Serial.printf("IDLE, query SLOW PIDs at %.3f s\n", slow_data_last_time / 1000.0);
+      } else if (millis() > fast_data_last_time + 1000) {
+        fast_data_last_time = millis();
+        obd_state = COOLANT_TEMP;  // Specify the first slow PID here
+        Serial.printf("IDLE, query FAST PIDs at %.3f s\n", fast_data_last_time / 1000.0);
+      } else {
+        // Serial.printf("[%.3f s] IDLE\n", millis() / 1000.0);
+      }
+      break;
+
+    case COOLANT_TEMP:
+      coolant_temperature = myELM327.engineCoolantTemp();
+      if (myELM327.nb_rx_state == ELM_SUCCESS) {
+        Serial.printf("Coolant temp = %.0f\n", coolant_temperature);
+        obd_state = OIL_TEMP;
+      } else if (myELM327.nb_rx_state != ELM_GETTING_MSG) {
+        myELM327.printError();
+        obd_state = OIL_TEMP;
+      }
+      break;
+
+    case OIL_TEMP:
+      // Not yet implemented
+      obd_state = ENG_RPM;
+      break;
+
+    case ENG_RPM:
+      eng_rpm = myELM327.rpm();
+      if (myELM327.nb_rx_state == ELM_SUCCESS) {
+        Serial.printf("Engine RPM = %.0f\n", eng_rpm);
+        obd_state = IDLE;
+      } else if (myELM327.nb_rx_state != ELM_GETTING_MSG) {
+        myELM327.printError();
+        obd_state = IDLE;
+      }
+      break;
+
+    case BATT_VOLT:
+      battery_voltage = myELM327.batteryVoltage();
+      if (myELM327.nb_rx_state == ELM_SUCCESS) {
+        Serial.printf("Battery voltage = %.1f\n", battery_voltage);
+        obd_state = IDLE;
+      } else if (myELM327.nb_rx_state != ELM_GETTING_MSG) {
+        myELM327.printError();
+        obd_state = IDLE;
+      }
+      break;
+  }
+}


### PR DESCRIPTION
Hi there, here is the non-blocking PR. I've tested this on my own car and it is working ok. This represets about 3 days full time work for my coding / dev speed 😄. Things to note:

1. @PowerBroker2 consider if you want to keep the blocking version of the API. This shouldn't be too hard, but might be confusing for new people using the library. For now I have replaced the blocking code with non-blocking.
2. I tried hard to keep the API unchanged as far as I could. After querying a PID, the application code needs to check if a message is still being received if the response is !ELM_SUCCESS, see examples `else if (myELM327.nb_rx_state != ELM_GETTING_MSG)`. An error has occurred if the response is none of these two values.
3. I have only implemented the `rpm` and `engineCoolantTemp` PID functions as examples so you guys can review the code. Unfortunately the trade-off for non-blocking is that the PID functions are a few more SLOCs. If and when it's accepted, then we can implement all the other PID functions. All the others are commented out.
4. I use PlatformIO and the C++ Intellisense extension to Visual Studio Code. It has a automatic formatting feature, so some changes are purley due to the formatter. It wasn't worth me manually undoing these so they wouldn't show up as changes.
5. I added a function `batteryVoltage` to read vehicle battery voltage. This is not actually a PID, it's just an AT command. This can be used as an example of how to issue AT commands and get response in a non-blocking fashion.
6. I created `sendCommand_Blocking` as it is handy for issuing blocking AT commands like in the `initializeELM` function.
7. There is one change that is unrelated to non-blocking. In PID queries, I added a `num_responses` to the query string. This is normally set to "1" for most PIDs, unless you kmow there is a multi-line response. It means the OBD scanner won't wait around to see if more responses are coming from the vehicle's ECU once it has received num_responses responses. This has two positive effects: 1) faster frame rates, I have achieved up to 15 Hz querying two PIDs. 2) no duplicate responses which @PowerBroker2 you see in your scanner. This also means the code in `findResponse` to identify `secondHeadIndex` is pretty much redundant (I left the code unchanged however as it does no harm).
8. I have provided 3 examples. The one called `examples/ESP32_M5Stack_Core2_non_block/non blocking M5Stack Core2.ino` could be removed, but I think quite a few people would appreciate this (it uses [one of these ESP32s](https://docs.m5stack.com/en/core/core2) with a built in high res IPS tft display). In `examples/non_blocking_2/non blocking example 2.ino` I have put in a simple scheduler to show how to query a number of PIDs at different rates.