### PR TITLE
Adds resetDTC() method.

### DIFF
--- a/examples/ESP32_Reset_DTC/ESP32_Reset_DTC.ino
+++ b/examples/ESP32_Reset_DTC/ESP32_Reset_DTC.ino
@@ -1,0 +1,43 @@
+#include "BluetoothSerial.h"
+#include "ELMduino.h"
+
+BluetoothSerial SerialBT;
+#define ELM_PORT SerialBT
+#define DEBUG_PORT Serial
+
+ELM327 myELM327;
+
+void setup()
+{
+    DEBUG_PORT.begin(115200);
+    // SerialBT.setPin("1234");
+    ELM_PORT.begin("ESP32", true);
+
+    if (!ELM_PORT.connect("OBDII"))
+    {
+        DEBUG_PORT.println("Couldn't connect to OBD scanner - Phase 1");
+        while (1)
+            ;
+    }
+
+    if (!myELM327.begin(ELM_PORT, true, 2000))
+    {
+        DEBUG_PORT.println("Couldn't connect to OBD scanner - Phase 2");
+        while (1)
+            ;
+    }
+
+    DEBUG_PORT.println("Connected to ELM327");
+    DEBUG_PORT.println("Sending DTC reset command...");
+
+    if (myELM327.resetDTC())
+    {
+        DEBUG_PORT.println("DTC reset successful.");
+    }
+    else
+    {
+        DEBUG_PORT.println("DTC reset failed.");
+    }
+}
+
+void loop(){}

--- a/src/ELMduino.cpp
+++ b/src/ELMduino.cpp
@@ -2517,3 +2517,46 @@ int8_t ELM327::get_vin_blocking(char vin[])
     }
     return nb_rx_state;
 }
+
+/*
+ bool ELM327::resetDTC()
+
+ Description:
+ ------------
+    * Resets the stored DTCs in the ECU. This is a blocking function.
+      Note: The SAE spec requires that scan tools verify that a reset
+            is intended ("Are you sure?") before sending the mode 04
+            reset command to the vehicle. See p.32 of ELM327 datasheet.
+
+ Inputs:
+ -------
+    * void
+
+ Return:
+ -------
+  * bool - Indicates the success (or not) of the reset command.
+*/
+bool ELM327::resetDTC()
+{
+    if (sendCommand_Blocking("04") == ELM_SUCCESS)
+    {
+        if (strstr(payload, "44") != NULL)
+        {
+            if(debugMode)
+            {
+                Serial.println("ELMduino: DTC successfully reset."); 
+            }
+                
+            return true;
+        }
+    }
+    else 
+    {
+        if(debugMode) 
+        {
+            Serial.println("ELMduino: Resetting DTC codes failed.");
+        }
+    }
+
+    return false; 
+}

--- a/src/ELMduino.h
+++ b/src/ELMduino.h
@@ -322,6 +322,7 @@ public:
 
 	float batteryVoltage(void);
 	int8_t get_vin_blocking(char vin[]);
+	bool resetDTC();
 
 	uint32_t supportedPIDs_1_20();
 


### PR DESCRIPTION
Does what it says on the tin; a method to reset all DTC codes. Includes an example program that utilizes the new method. Tested w/ a TTGO LoRa32 T3 v2.1.6 board using Veepeak and unbranded Bluetooth adapters. 