### PR TITLE
Fix for issue myELM327.supportedPIDs_1_20()  not working as expected …

### DIFF
--- a/examples/ESP32_CheckPIDs_1_20/ESP32_CheckPIDs_1_20.ino
+++ b/examples/ESP32_CheckPIDs_1_20/ESP32_CheckPIDs_1_20.ino
@@ -1,0 +1,53 @@
+#include "BluetoothSerial.h"
+#include "ELMduino.h"
+
+BluetoothSerial SerialBT;
+#define ELM_PORT SerialBT
+#define DEBUG_PORT Serial
+
+ELM327 myELM327;
+
+uint32_t rpm = 0;
+
+void setup()
+{
+#if LED_BUILTIN
+    pinMode(LED_BUILTIN, OUTPUT);
+    digitalWrite(LED_BUILTIN, LOW);
+#endif
+
+    DEBUG_PORT.begin(115200);
+    // SerialBT.setPin("1234");
+    ELM_PORT.begin("ArduHUD", true);
+
+    if (!ELM_PORT.connect("OBDII"))
+    {
+        DEBUG_PORT.println("Couldn't connect to OBD scanner - Phase 1");
+        while (1)
+            ;
+    }
+
+    if (!myELM327.begin(ELM_PORT, true, 2000))
+    {
+        Serial.println("Couldn't connect to OBD scanner - Phase 2");
+        while (1)
+            ;
+    }
+
+    Serial.println("Connected to ELM327");
+}
+
+void loop()
+{
+    uint32_t pids = myELM327.supportedPIDs_1_20();
+
+    if (myELM327.nb_rx_state == ELM_SUCCESS)
+    {
+        Serial.print("Supported PIDS: "); Serial.println(pids);
+        delay(10000);
+    }
+    else if (myELM327.nb_rx_state != ELM_GETTING_MSG)
+    {
+        myELM327.printError();
+    }       
+}

--- a/src/ELMduino.cpp
+++ b/src/ELMduino.cpp
@@ -2359,7 +2359,7 @@ uint64_t ELM327::findResponse()
         {
             uint8_t payloadIndex = firstDatum + i;
             uint8_t bitsOffset = 4 * (numPayChars - i - 1);
-            response = response | (ctoi(payload[payloadIndex]) << bitsOffset);
+            response = response | ((uint64_t)ctoi(payload[payloadIndex]) << bitsOffset);
         }
 
         // It is useful to have the response bytes


### PR DESCRIPTION
Fixed the issue with incorrect values being returned from findResponse() even though the received bytes were correct. The bug was caused by bit shifting the uint8_t value returned by ctoi() by more than 8 bits (undefined behaviour). Fix is to cast the result of ctoi() to uint64_t before doing the left shift. 

Also note in the issue #157, the sample code has a bug were the pids var is a signed int, which will cause an error; it should be unsigned. See example program _Check_PIDs_1_20.ino_ for a working version. 