### PR TITLE
Adds convenience method to query if a particular PID is supported 

### DIFF
--- a/examples/ESP32_Check_PID_Support/ESP32_Check_PID_Support.ino
+++ b/examples/ESP32_Check_PID_Support/ESP32_Check_PID_Support.ino
@@ -1,0 +1,59 @@
+#include "BluetoothSerial.h"
+#include "ELMduino.h"
+
+BluetoothSerial SerialBT;
+#define ELM_PORT SerialBT
+#define DEBUG_PORT Serial
+
+ELM327 myELM327;
+
+uint32_t rpm = 0;
+
+void setup()
+{
+#if LED_BUILTIN
+    pinMode(LED_BUILTIN, OUTPUT);
+    digitalWrite(LED_BUILTIN, LOW);
+#endif
+
+    DEBUG_PORT.begin(115200);
+    // SerialBT.setPin("1234");
+    ELM_PORT.begin("ArduHUD", true);
+
+    if (!ELM_PORT.connect("ELMULATOR"))
+    {
+        DEBUG_PORT.println("Couldn't connect to OBD scanner - Phase 1");
+        while (1)
+            ;
+    }
+
+    if (!myELM327.begin(ELM_PORT, true, 2000))
+    {
+        DEBUG_PORT.println("Couldn't connect to OBD scanner - Phase 2");
+        while (1)
+            ;
+    }
+
+    Serial.println("Connected to ELM327");
+}
+
+void loop()
+{
+    uint8_t pid = ENGINE_RPM;
+    bool pidOK = myELM327.isPidSupported(pid);
+    if (myELM327.nb_rx_state == ELM_SUCCESS)
+    {
+        if(pidOK) {
+            Serial.print("PID "); Serial.print(pid); Serial.println(" is supported");
+        }
+        else 
+        {
+            Serial.print("PID "); Serial.print(pid); Serial.println(" is not supported");
+        }
+        delay(10000);
+    }
+    else if (myELM327.nb_rx_state != ELM_GETTING_MSG)
+    {
+        myELM327.printError();
+    }    
+}

--- a/src/ELMduino.cpp
+++ b/src/ELMduino.cpp
@@ -2788,3 +2788,59 @@ void ELM327::currentDTCCodes(const bool &isBlocking)
         }
     }
 }
+
+
+/*
+ bool ELM327::isPidSupported(uint8_t pid)
+
+ Description:
+ ------------
+  * Checks if a particular PID is supported by the connected ECU.
+
+  * This is a convenience method that selects the correct supportedPIDS_xx_xx() query and parses
+    the bit-encoded result, returning a simple Boolean value indicating PID support from the ECU.
+
+ Inputs:
+ -------
+  * uint8_t pid - the PID to check for support. 
+
+ Return:
+ -------
+  * bool - Whether or not the queried PID is supported by the ECU. 
+*/
+bool ELM327::isPidSupported(uint8_t pid)
+{
+    uint8_t pidInterval = (pid / PID_INTERVAL_OFFSET) * PID_INTERVAL_OFFSET;
+    uint8_t checkPid = 0;
+
+    switch (pidInterval)
+    {
+    case SUPPORTED_PIDS_1_20:
+        supportedPIDs_1_20();
+        break;
+
+    case SUPPORTED_PIDS_21_40:
+        supportedPIDs_21_40();
+        pid = (pid - SUPPORTED_PIDS_21_40);
+        break;
+
+    case SUPPORTED_PIDS_41_60:
+        supportedPIDs_41_60();
+        pid = (pid - SUPPORTED_PIDS_41_60);
+        break;
+
+    case SUPPORTED_PIDS_61_80:
+        supportedPIDs_61_80();
+        pid = (pid - SUPPORTED_PIDS_61_80);
+        break;
+    
+    default:
+        break;
+    }      
+
+    if (nb_rx_state == ELM_SUCCESS)
+    {
+        return ((response >> (32 - pid)) & 0x1);
+    }
+    return false;
+}

--- a/src/ELMduino.h
+++ b/src/ELMduino.h
@@ -139,7 +139,7 @@ const uint8_t AUX_INPUT_OUTPUT_SUPPORTED       = 101; // 0x65 - bit encoded
 
 const uint8_t SERVICE_02                       = 2;
 const uint8_t SERVICE_03                       = 3;
-
+const uint8_t PID_INTERVAL_OFFSET 			   = 0x20;
 
 
 //-------------------------------------------------------------------------------------//
@@ -329,6 +329,7 @@ public:
 	int8_t get_vin_blocking(char vin[]);
 	bool resetDTC();
 	void currentDTCCodes(const bool& isBlocking = true);
+	bool isPidSupported(uint8_t pid);
 
 	uint32_t supportedPIDs_1_20();
 


### PR DESCRIPTION
This is a convenience method that selects the correct supportedPIDS_xx_xx() query and parses the bit-encoded result, returning a simple Boolean value indicating PID support from the ECU. 

This change includes an example program showing how to use the new method. Just call the new method with the PID you are interested in:

```
    uint8_t pid = ENGINE_RPM;
    bool pidOK = myELM327.isPidSupported(pid);
```

