### PR TITLE
Fix for #211 Value returned by supportedPIDS_xx_xx() methods is off by one bit.  

### DIFF
--- a/src/ELMduino.h
+++ b/src/ELMduino.h
@@ -318,12 +318,12 @@ public:
 	uint64_t findResponse();
 	bool queryPID(const uint8_t& service, const uint16_t& pid, const uint8_t& num_responses = 1);
 	bool queryPID(char queryStr[]);
-	float processPID(const uint8_t& service, const uint16_t& pid, const uint8_t& num_responses, const uint8_t& numExpectedBytes, const float& scaleFactor = 1, const float& bias = 0);
+	double processPID(const uint8_t& service, const uint16_t& pid, const uint8_t& num_responses, const uint8_t& numExpectedBytes, const float& scaleFactor = 1, const float& bias = 0);
 	void sendCommand(const char *cmd);
 	int8_t sendCommand_Blocking(const char *cmd);
 	int8_t get_response();
 	bool timeout();
-	float conditionResponse(const uint8_t& numExpectedBytes, const float& scaleFactor = 1, const float& bias = 0);
+	double conditionResponse(const uint8_t& numExpectedBytes, const float& scaleFactor = 1, const float& bias = 0);
 
 	float batteryVoltage(void);
 	int8_t get_vin_blocking(char vin[]);


### PR DESCRIPTION
Changes processPID() and conditionResponse() to return double instead of float to preserve all bits of _response_.
Adds a shortcut to return  _response_ directly without scale/bias processing where none is needed, including when the return value is bit-encoded. 