### PR TITLE
Update for fix for #211

### DIFF
--- a/src/ELMduino.cpp
+++ b/src/ELMduino.cpp
@@ -393,7 +393,7 @@ int8_t ELM327::nextIndex(char const *str,
 }
 
 /*
- void ELM327::conditionResponse(const uint8_t &numExpectedBytes, const float &scaleFactor, const float &bias)
+ double ELM327::conditionResponse(const uint8_t &numExpectedBytes, const float &scaleFactor, const float &bias)
 
  Description:
  ------------
@@ -408,9 +408,9 @@ int8_t ELM327::nextIndex(char const *str,
 
  Return:
  -------
-  * float - Converted numerical value
+  * double - Converted numerical value
 */
-double ELM327::conditionResponse(const uint8_t &numExpectedBytes, const float &scaleFactor, const float &bias)
+double ELM327::conditionResponse(const uint8_t &numExpectedBytes, const double &scaleFactor, const float &bias)
 {
     uint8_t numExpectedPayChars = numExpectedBytes * 2;
     uint8_t payCharDiff = numPayChars - numExpectedPayChars;
@@ -475,7 +475,7 @@ double ELM327::conditionResponse(const uint8_t &numExpectedBytes, const float &s
         }
         else 
         {
-            return ((double)(response >> (4 * payCharDiff)) * scaleFactor) + bias;
+            return ((response >> (4 * payCharDiff)) * scaleFactor) + bias;
         }
         
     }
@@ -575,7 +575,7 @@ bool ELM327::queryPID(char queryStr[])
 }
 
 /*
- float ELM327::processPID(const uint8_t& service, const uint16_t& pid, const uint8_t& num_responses, const uint8_t& numExpectedBytes, const float& scaleFactor, const float& bias)
+ double ELM327::processPID(const uint8_t& service, const uint16_t& pid, const uint8_t& num_responses, const uint8_t& numExpectedBytes, const float& scaleFactor, const float& bias)
 
  Description:
  ------------
@@ -597,7 +597,7 @@ bool ELM327::queryPID(char queryStr[])
  -------
   * float - The PID value if successfully received, else 0.0
 */
-double ELM327::processPID(const uint8_t &service, const uint16_t &pid, const uint8_t &num_responses, const uint8_t &numExpectedBytes, const float &scaleFactor, const float &bias)
+double ELM327::processPID(const uint8_t &service, const uint16_t &pid, const uint8_t &num_responses, const uint8_t &numExpectedBytes, const double &scaleFactor, const float &bias)
 {
     if (nb_query_state == SEND_COMMAND)
     {

--- a/src/ELMduino.h
+++ b/src/ELMduino.h
@@ -318,12 +318,12 @@ public:
 	uint64_t findResponse();
 	bool queryPID(const uint8_t& service, const uint16_t& pid, const uint8_t& num_responses = 1);
 	bool queryPID(char queryStr[]);
-	double processPID(const uint8_t& service, const uint16_t& pid, const uint8_t& num_responses, const uint8_t& numExpectedBytes, const float& scaleFactor = 1, const float& bias = 0);
+	double processPID(const uint8_t& service, const uint16_t& pid, const uint8_t& num_responses, const uint8_t& numExpectedBytes, const double& scaleFactor = 1, const float& bias = 0);
 	void sendCommand(const char *cmd);
 	int8_t sendCommand_Blocking(const char *cmd);
 	int8_t get_response();
 	bool timeout();
-	double conditionResponse(const uint8_t& numExpectedBytes, const float& scaleFactor = 1, const float& bias = 0);
+	double conditionResponse(const uint8_t& numExpectedBytes, const double& scaleFactor = 1, const float& bias = 0);
 
 	float batteryVoltage(void);
 	int8_t get_vin_blocking(char vin[]);


### PR DESCRIPTION
Because _scaleFactor_ in processPID() and conditionResponse() is a float, the product of (_response * scaleFactor_) is automatically cast to float and potentially loses data. This change makes _scaleFactor_ a double as well, keeping _response_ a full 64 bits wide. 

Not all of the return statements in conditionResponse() had the explicit cast to double implemented previously; with this change the typecast is no longer needed as it always returns a double. 

I have updated the comment/description for both methods to reflect the change in return type.