### PR TITLE
Fix for Custom PIDs #218

### DIFF
--- a/src/ELMduino.h
+++ b/src/ELMduino.h
@@ -315,7 +315,7 @@ public:
 	bool begin(Stream& stream, const bool& debug = false, const uint16_t& timeout = 1000, const char& protocol = '0', const uint16_t& payloadLen = 40, const byte& dataTimeout = 0);
 	bool initializeELM(const char& protocol = '0', const byte& dataTimeout = 0);
 	void flushInputBuff();
-	uint64_t findResponse();
+	uint64_t findResponse(const uint8_t &service, const uint8_t &pid);
 	bool queryPID(const uint8_t& service, const uint16_t& pid, const uint8_t& num_responses = 1);
 	bool queryPID(char queryStr[]);
 	double processPID(const uint8_t& service, const uint16_t& pid, const uint8_t& num_responses, const uint8_t& numExpectedBytes, const double& scaleFactor = 1, const float& bias = 0);
@@ -421,6 +421,7 @@ public:
 private:
 	char query[QUERY_LEN] = { '\0' };
 	bool longQuery = false;
+	bool isMode0x22Query = false;
 	uint32_t currentTime;
 	uint32_t previousTime;
 


### PR DESCRIPTION
Mode 0x22 response headers always zero-pad the pid to 4 chars, even for a 2-char pid. That confused the header detection and response parsing. This change checks for the mode and pid in findResponse() and adjusts the expected header accordingly.