### PR TITLE
(new) Added parseCANResponse() method to parse multiline CAN responses

### DIFF
--- a/examples/ESP32_CustomMultilinePID/ESP32_CustomMultilinePID.ino
+++ b/examples/ESP32_CustomMultilinePID/ESP32_CustomMultilinePID.ino
@@ -68,8 +68,8 @@ void loop()
     
     if (myELM327.nb_rx_state == ELM_SUCCESS)    // Our response is fully received, let's get our data
     {          
-        double dpf = myELM327.conditionResponse(calcDPF); // Apply the formula for the fuel rail pressure                                             
-        Serial.println(dpf);       // Print the adjusted value
+        double dpf = myELM327.conditionResponse(calcDPF); // Apply the formula for dpf                                             
+        Serial.println(dpf);                    // Print the adjusted value
         nb_query_state = SEND_COMMAND;          // Reset the query state for the next command
         delay(5000);                            // Wait 5 seconds until we query again
     }

--- a/examples/ESP32_CustomMultilinePID/ESP32_CustomMultilinePID.ino
+++ b/examples/ESP32_CustomMultilinePID/ESP32_CustomMultilinePID.ino
@@ -1,0 +1,85 @@
+/* 
+
+This example shows how to query and process OBD2 standard PIDs that
+return a multiline response and require custom processing.
+
+Processing Response with a custom calculation function
+In this example, we manually extract the data value from the query response and perform
+some post-processing to calculate the correct value. 
+
+Managing Query State
+We also demonstrate managing the query state used by the loop() method. This is typically
+managed internally by ELMduino for standard PID methods. 
+
+*/
+
+#include "BluetoothSerial.h"
+#include "ELMduino.h"
+
+BluetoothSerial SerialBT;
+#define ELM_PORT SerialBT
+#define DEBUG_PORT Serial
+
+ELM327 myELM327;
+
+int nb_query_state = SEND_COMMAND; // Set the inital query state ready to send a command
+
+
+// Applies calculation formula for PID 0x22 (Fuel Rail Pressure)
+double calcFRP() {
+    uint8_t A = myELM327.payload[7];
+    uint8_t B = myELM327.payload[6];
+    return 0.079 * (double)((A * 256) + B);
+}
+
+void setup() 
+{    
+    DEBUG_PORT.begin(115200);
+    // SerialBT.setPin("1234");
+    ELM_PORT.begin("ArduHUD", true);
+
+    if (!ELM_PORT.connect("OBDII"))
+    {
+        DEBUG_PORT.println("Couldn't connect to ELM327 device.");
+        while (1);
+    }
+
+    if (!myELM327.begin(ELM_PORT, true, 2000))
+    {
+        Serial.println("ELM327 device couldn't connect to ECU.");
+        while (1);
+    }
+
+    Serial.println("Connected to ELM327");
+
+}
+ 
+void loop() 
+{
+    if (nb_query_state == SEND_COMMAND)         // We are ready to send a new command
+    {
+        myELM327.sendCommand("0122");          // Send the PID commnad
+        nb_query_state = WAITING_RESP;          // Set the query state so we are waiting for response
+    }
+    else if (nb_query_state == WAITING_RESP)    // Our query has been sent, check for a response
+    {
+        myELM327.get_response();                // Each time through the loop we will check again
+    }
+    
+    if (myELM327.nb_rx_state == ELM_SUCCESS)    // Our response is fully received, let's get our data
+    {   
+        if (NULL != strchr(myELM327.payload, ':'))
+            myELM327.parseCANResponse();        // Process a multiline response into a single uint64_t response       
+        double fuelRailPressure = myELM327.conditionResponse(calcFRP); // Apply the formula for the fuel rail pressure                                             
+        Serial.println(fuelRailPressure);       // Print the adjusted value
+        nb_query_state = SEND_COMMAND;          // Reset the query state for the next command
+        delay(5000);                            // Wait 5 seconds until we query again
+    }
+    
+    else if (myELM327.nb_rx_state != ELM_GETTING_MSG)
+    {                                           // If state == ELM_GETTING_MSG, response is not yet complete. Restart the loop.
+        nb_query_state = SEND_COMMAND;          // Reset the query state for the next command
+        myELM327.printError();
+        delay(5000);                            // Wait 5 seconds until we query again
+    }
+}

--- a/src/ELMduino.cpp
+++ b/src/ELMduino.cpp
@@ -680,7 +680,7 @@ double ELM327::processPID(const uint8_t&  service,
         if (nb_rx_state == ELM_SUCCESS)
         {
             nb_query_state = SEND_COMMAND; // Reset the query state machine for next command
-            findResponse(service, pid);
+            findResponse();
             return conditionResponse(numExpectedBytes, scaleFactor, bias);
         }
         else if (nb_rx_state != ELM_GETTING_MSG)
@@ -2422,7 +2422,7 @@ void ELM327::parseMultiLineResponse() {
         }
     
         if (debugMode) {
-            Serial.print("Found line in response: ");
+            Serial.print(F("Found line in response: "));
             Serial.println(line);
         }
         // Step 2: Check if this is the first line of the response
@@ -2433,7 +2433,7 @@ void ELM327::parseMultiLineResponse() {
             if (strlen(line) > 3) {
                 if (debugMode)
                 {
-                    Serial.print("Found header in response line: ");
+                    Serial.print(F("Found header in response line: "));
                     Serial.println(line); 
                 }
             }
@@ -2441,7 +2441,7 @@ void ELM327::parseMultiLineResponse() {
                 if (strlen(line) > 0) {
                     totalBytes = strtol(line, NULL, 16) * 2;
                     if (debugMode) {
-                        Serial.print("totalBytes = ");
+                        Serial.print(F("totalBytes = "));
                         Serial.println(totalBytes);
                     }
                 }
@@ -2457,7 +2457,7 @@ void ELM327::parseMultiLineResponse() {
                 bytesReceived += bytesToCopy;
 
                 if (debugMode) {
-                    Serial.print("Response data: ");
+                    Serial.print(F("Response data: "));
                     Serial.println(dataStart);
                 }
             }
@@ -2478,7 +2478,7 @@ void ELM327::parseMultiLineResponse() {
     payload[nullTermPos] = '\0'; // Ensure null termination
     if (debugMode) 
     {
-        Serial.print("Parsed multiline response: ");
+        Serial.print(F("Parsed multiline response: "));
         Serial.println(payload);
     }
 }
@@ -2500,8 +2500,7 @@ void ELM327::parseMultiLineResponse() {
  -------
   * void
 */
-uint64_t ELM327::findResponse(const uint8_t& service,
-                              const uint8_t& pid)
+uint64_t ELM327::findResponse()
 {
     uint8_t firstDatum = 0;
     char header[7] = {'\0'};
@@ -2577,7 +2576,7 @@ uint64_t ELM327::findResponse(const uint8_t& service,
 
             if (debugMode)
             {
-                Serial.print("\tProcessing hex nibble: ");
+                Serial.print(F("\tProcessing hex nibble: "));
                 Serial.println(payload[payloadIndex]);
             }
             response = response | ((uint64_t)ctoi(payload[payloadIndex]) << bitsOffset);

--- a/src/ELMduino.cpp
+++ b/src/ELMduino.cpp
@@ -439,6 +439,16 @@ int8_t ELM327::nextIndex(char const *str,
     return p - r;
 }
 
+void ELM327::removeChar(char *from, const char *remove)
+{
+    size_t i = 0, j = 0;
+    while (from[i]) {
+        if (!strchr(remove, from[i]))
+            from[j++] = from[i];
+        i++;
+    }
+    from[j] = '\0'; 
+}
 /*
  double ELM327::conditionResponse(const uint8_t &numExpectedBytes, const float &scaleFactor, const float &bias)
 
@@ -2361,9 +2371,14 @@ int8_t ELM327::get_response(void)
     }
 
     nb_rx_state = ELM_SUCCESS;
-    if (NULL != strchr(payload, ':'))
+    // Need to process multiline repsonses, remove '\r' from non multiline resp
+    if (NULL != strchr(payload, ':')) {
         parseMultiLineResponse();
-
+    } 
+    else {
+        removeChar(payload, " \r");
+    }
+    recBytes = strlen(payload); 
     return nb_rx_state;
 }
 
@@ -2551,7 +2566,7 @@ uint64_t ELM327::findResponse(const uint8_t& service,
             if (debugMode)
                 Serial.println(F("Single response detected"));
 
-            numPayChars = recBytes - firstDatum;
+            numPayChars = strlen(payload) - firstDatum;
         }
 
         response = 0;

--- a/src/ELMduino.h
+++ b/src/ELMduino.h
@@ -445,4 +445,5 @@ private:
     int8_t  nextIndex(char const *str,
                       char const *target,
                       uint8_t     numOccur = 1);
+    void    removeChar(char *from, const char *remove);
 };

--- a/src/ELMduino.h
+++ b/src/ELMduino.h
@@ -319,35 +319,19 @@ public:
         char    codes[DTC_MAX_CODES][DTC_CODE_LEN];
     } DTC_Response;
     
-            bool     begin(      Stream&   stream,
-                           const bool&     debug       = false,
-                           const uint16_t& timeout     = 1000,
-                           const char&     protocol    = '0',
-                           const uint16_t& payloadLen  = 40,
-                           const byte&     dataTimeout = 0);
-            bool     initializeELM(const char& protocol    = '0',
-                                   const byte& dataTimeout = 0);
-            void     flushInputBuff();
-    virtual uint64_t findResponse(const uint8_t &service,
-                                  const uint8_t &pid);
-            void     queryPID(const uint8_t&  service,
-                              const uint16_t& pid,
-                              const uint8_t&  num_responses = 1);
-            void     queryPID(char queryStr[]);
-            double   processPID(const uint8_t&  service,
-                                const uint16_t& pid,
-                                const uint8_t&  num_responses,
-                                const uint8_t&  numExpectedBytes,
-                                const double&   scaleFactor = 1,
-                                const float&    bias        = 0);
-            void     sendCommand(const char *cmd);
-            int8_t   sendCommand_Blocking(const char *cmd);
-            int8_t   get_response();
-            bool     timeout();
-            double   conditionResponse(const uint8_t& numExpectedBytes,
-                                       const double&  scaleFactor = 1,
-                                       const float&   bias        = 0);
-
+    bool begin(Stream& stream, const bool& debug = false, const uint16_t& timeout = 1000, const char& protocol = '0', const uint16_t& payloadLen = 40, const byte& dataTimeout = 0);
+    bool initializeELM(const char& protocol = '0', const byte& dataTimeout = 0);
+    void flushInputBuff();
+    uint64_t findResponse(const uint8_t &service, const uint8_t &pid);
+    void queryPID(const uint8_t& service, const uint16_t& pid, const uint8_t& num_responses = 1);
+    void queryPID(char queryStr[]);
+    double processPID(const uint8_t& service, const uint16_t& pid, const uint8_t& num_responses, const uint8_t& numExpectedBytes, const double& scaleFactor = 1, const float& bias = 0);
+    void sendCommand(const char *cmd);
+    int8_t sendCommand_Blocking(const char *cmd);
+    int8_t get_response();
+    bool timeout();
+    double conditionResponse(const uint8_t& numExpectedBytes, const double& scaleFactor = 1, const float& bias = 0);
+    
     float  batteryVoltage(void);
     int8_t get_vin_blocking(char vin[]);
     bool   resetDTC();
@@ -455,6 +439,8 @@ private:
     void    formatQueryArray(const uint8_t&  service,
                              const uint16_t& pid, 
                              const uint8_t&  num_responses);
+    void parseCANResponse();
+
     uint8_t ctoi(uint8_t value);
     int8_t  nextIndex(char const *str,
                       char const *target,

--- a/src/ELMduino.h
+++ b/src/ELMduino.h
@@ -322,7 +322,7 @@ public:
     bool begin(Stream& stream, const bool& debug = false, const uint16_t& timeout = 1000, const char& protocol = '0', const uint16_t& payloadLen = 128, const byte& dataTimeout = 0);
     bool initializeELM(const char& protocol = '0', const byte& dataTimeout = 0);
     void flushInputBuff();
-    uint64_t findResponse(const uint8_t &service, const uint8_t &pid);
+    uint64_t findResponse();
     void queryPID(const uint8_t& service, const uint16_t& pid, const uint8_t& num_responses = 1);
     void queryPID(char queryStr[]);
     double processPID(const uint8_t& service, const uint16_t& pid, const uint8_t& num_responses, const uint8_t& numExpectedBytes, const double& scaleFactor = 1, const float& bias = 0);

--- a/src/ELMduino.h
+++ b/src/ELMduino.h
@@ -319,7 +319,7 @@ public:
         char    codes[DTC_MAX_CODES][DTC_CODE_LEN];
     } DTC_Response;
     
-    bool begin(Stream& stream, const bool& debug = false, const uint16_t& timeout = 1000, const char& protocol = '0', const uint16_t& payloadLen = 40, const byte& dataTimeout = 0);
+    bool begin(Stream& stream, const bool& debug = false, const uint16_t& timeout = 1000, const char& protocol = '0', const uint16_t& payloadLen = 128, const byte& dataTimeout = 0);
     bool initializeELM(const char& protocol = '0', const byte& dataTimeout = 0);
     void flushInputBuff();
     uint64_t findResponse(const uint8_t &service, const uint8_t &pid);
@@ -337,7 +337,7 @@ public:
     bool   resetDTC();
     void   currentDTCCodes(const bool& isBlocking = true);
     bool   isPidSupported(uint8_t pid);
-    void parseCANResponse();
+    void parseMultiLineResponse();
     
     uint32_t supportedPIDs_1_20();
 

--- a/src/ELMduino.h
+++ b/src/ELMduino.h
@@ -313,7 +313,7 @@ public:
     byte responseByte_5;
     byte responseByte_6;
     byte responseByte_7;
-
+    
     struct dtcResponse {
         uint8_t codesFound = 0;
         char    codes[DTC_MAX_CODES][DTC_CODE_LEN];
@@ -331,13 +331,14 @@ public:
     int8_t get_response();
     bool timeout();
     double conditionResponse(const uint8_t& numExpectedBytes, const double& scaleFactor = 1, const float& bias = 0);
-    
+    double conditionResponse(double (*func)());
     float  batteryVoltage(void);
     int8_t get_vin_blocking(char vin[]);
     bool   resetDTC();
     void   currentDTCCodes(const bool& isBlocking = true);
     bool   isPidSupported(uint8_t pid);
-
+    void parseCANResponse();
+    
     uint32_t supportedPIDs_1_20();
 
     uint32_t monitorStatus();
@@ -439,7 +440,6 @@ private:
     void    formatQueryArray(const uint8_t&  service,
                              const uint16_t& pid, 
                              const uint8_t&  num_responses);
-    void parseCANResponse();
 
     uint8_t ctoi(uint8_t value);
     int8_t  nextIndex(char const *str,


### PR DESCRIPTION
> This is embarrassing to admit, but I'm not actually an expert on PID responses. Do you (or anyone else who may be reading this) know why some PID responses have the data after the second colon ([#275](https://github.com/PowerBroker2/ELMduino/issues/275)) and other responses like this be after the first semicolon?

I know you closed #279, but I have some additional info, having spent some quality time with the ELM327 data sheet. The responses we are seeing are multiline CAN responses. It's not really the colons that are separating the response components, it's the lines. The raw response (in the first instance) is this:

```
009
0:417A00013C00
1:00000000000000
```
The first line says there are 9 (hex) total bytes in the response. The "0:" and "1:" are line numbers for the response. So the correct parsing of this is that the PID response header "417A" is the first two bytes and the data is in the following 7 bytes (14 hex nibbles) and continues into the second line. Confusingly, the data bytes in the second line are all zero and the line is zero padded. 

I wrote a method to do the multiline CAN response parsing according to the ELM327 data sheet, but what I don't understand currently is why the two adapters used are producing different responses. The first appears to be correct, but the second (vlink) includes the PID as an extra line and does not include all of the data required for 0x009 bytes of response data. I hope I'm explaining this properly.

It works in this particular case, but I think that is more of a fluke and it could fail in others. A generalized and correct parsing of a multiline CAN response should be more reliable with other PIDs or devices. I think this change warrants review & discussion before implementation. Also, I don't have any way to test with an actual device. The method is called from findResponse() if a multiline CAN response is detected and it modifies the payload to the "usual" format for continued processing like other responses. 
