### PR TITLE
Initialize newResponse manually

### DIFF
--- a/src/ELMduino.cpp
+++ b/src/ELMduino.cpp
@@ -2610,7 +2610,9 @@ void ELM327::parseMultiLineResponse() {
     uint8_t totalBytes = 0;
     uint8_t bytesReceived = 0;
     bool headerFound = false;
-    char newResponse[PAYLOAD_LEN] = {0};
+    char newResponse[PAYLOAD_LEN];
+    memset(newResponse, 0, PAYLOAD_LEN * sizeof(char)); // Initialize newResponse to empty string
+    
     char line[256] = "";
     char* start = payload;
     char* end = strchr(start, '\r');


### PR DESCRIPTION
I was getting an error when compiling version 3.4.0: 
```
ELMDuino\src\ELMduino.cpp:2613:39: error: variable-sized object 'newResponse' may not be initialized
    char newResponse[PAYLOAD_LEN] = {0};
```

This is caused by PAYLOAD_LEN not being a compile time constant, so I fixed it by manually initializing the array.